### PR TITLE
fix(remix): custom sw using wrong virtual modules

### DIFF
--- a/src/customize/remix.ts
+++ b/src/customize/remix.ts
@@ -35,7 +35,7 @@ export function customize(prompts: PromptsData) {
   // update app/routes/_index.tsx
   editFile(path.resolve(rootPath, 'app', 'routes', '_index.tsx'), (content) => {
     return content
-      .replace('"New Remix App"', `title: "${name}"`)
+      .replace('"New Remix App"', `"${name}"`)
       .replace('{ name: "description", content: "Welcome to Remix!" },', `{ name: "description", content: "${description || name}!" },`)
       .replace('<h1>Welcome to Remix</h1>', `<h1>Welcome to ${name}</h1>`)
   })

--- a/templates/template-custom-remix/app/claims-sw.ts
+++ b/templates/template-custom-remix/app/claims-sw.ts
@@ -36,6 +36,13 @@ if (import.meta.env.DEV) {
   }
 }
 
+// in ssr mode, we only intercept root page
+if (import.meta.env.PROD) {
+  if (ssr) {
+    allowlist = [new RegExp(`^${url}$`)];
+  }
+}
+
 // to allow work offline
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL(ssr ? url : "index.html"),

--- a/templates/template-custom-remix/app/claims-sw.ts
+++ b/templates/template-custom-remix/app/claims-sw.ts
@@ -3,17 +3,21 @@ import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from
 import { clientsClaim } from "workbox-core";
 import { NavigationRoute, registerRoute } from "workbox-routing";
 import { setupRoutes } from "./shared-sw";
-import { ssr } from "@vite-pwa/remix/sw";
+import { ssr, navigateFallback } from "virtual:vite-pwa/remix/sw";
 
 declare let self: ServiceWorkerGlobalScope;
+
+const url = navigateFallback ?? "/";
 
 // self.__WB_MANIFEST is the default injection point
 const manifest = self.__WB_MANIFEST
 if (import.meta.env.DEV) {
-  if (ssr) {
-    // add the navigateFallback to the manifest
-    manifest.push({ url: "/", revision: Math.random().toString() });
+  const entry = manifest.findIndex((entry) => typeof entry !== 'string' && entry.url === url);
+  if (entry !== -1) {
+    manifest.splice(entry, 1);
   }
+  // add the navigateFallback to the manifest
+  manifest.push({ url, revision: Math.random().toString() });
 }
 
 precacheAndRoute(manifest);
@@ -23,12 +27,18 @@ cleanupOutdatedCaches();
 
 let allowlist: RegExp[] | undefined;
 // in dev mode, we disable precaching to avoid caching issues
-if (import.meta.env.DEV)
-  allowlist = [/^\/$/];
+if (import.meta.env.DEV) {
+  if (ssr) {
+    // add the navigateFallback to the manifest
+    allowlist = [new RegExp(`^${url}$`)];
+  } else {
+    allowlist = [/^index.html$/];
+  }
+}
 
 // to allow work offline
 registerRoute(new NavigationRoute(
-  createHandlerBoundToURL(ssr ? "/" : "index.html"),
+  createHandlerBoundToURL(ssr ? url : "index.html"),
   { allowlist },
 ));
 

--- a/templates/template-custom-remix/app/prompt-sw.ts
+++ b/templates/template-custom-remix/app/prompt-sw.ts
@@ -40,6 +40,13 @@ if (import.meta.env.DEV) {
   }
 }
 
+// in ssr mode, we only intercept root page
+if (import.meta.env.PROD) {
+  if (ssr) {
+    allowlist = [new RegExp(`^${url}$`)];
+  }
+}
+
 // to allow work offline
 registerRoute(new NavigationRoute(
     createHandlerBoundToURL(ssr ? url : "index.html"),

--- a/templates/template-custom-remix/app/shared-sw.ts
+++ b/templates/template-custom-remix/app/shared-sw.ts
@@ -1,26 +1,26 @@
-import { dynamicRoutes, staticRoutes } from '@vite-pwa/remix/sw'
-import { registerRoute } from 'workbox-routing'
-import { CacheableResponsePlugin } from 'workbox-cacheable-response'
-import { NetworkOnly, StaleWhileRevalidate } from 'workbox-strategies'
+import { dynamicRoutes, staticRoutes } from "virtual:vite-pwa/remix/sw";
+import { registerRoute } from "workbox-routing";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
+import { NetworkOnly, StaleWhileRevalidate } from "workbox-strategies";
 
 export function setupRoutes() {
   // disable precaching in dev
   if (import.meta.env.PROD) {
-    const baseUrl = import.meta.env.BASE_URL
+    const baseUrl = import.meta.env.BASE_URL;
     const useStaticRoutes = staticRoutes.reduce((acc, r) => {
-      acc.push(`(${r.path!})`)
-      return acc
-    }, [] as string[])
+      acc.push(`(${r.path!})`);
+      return acc;
+    }, [] as string[]);
     const useDynamicRoutes = dynamicRoutes.reduce((acc, r) => {
-      acc.push(r.path!)
-      return acc
-    }, [] as string[])
+      acc.push(r.path!);
+      return acc;
+    }, [] as string[]);
     if (useStaticRoutes.length) {
-      const staticRoutesRegexp = new RegExp(`^${baseUrl}(${useStaticRoutes.join('|')})$`)
+      const staticRoutesRegexp = new RegExp(`^${baseUrl}(${useStaticRoutes.join("|")})$`);
       registerRoute(
-        ({ request, sameOrigin, url }) => request.destination === 'document' && sameOrigin && staticRoutesRegexp.test(url.pathname),
+        ({ request, sameOrigin, url }) => request.destination === "document" && sameOrigin && staticRoutesRegexp.test(url.pathname),
         new StaleWhileRevalidate({
-          cacheName: 'static-pages',
+          cacheName: "static-pages",
           matchOptions: {
             ignoreVary: true,
             ignoreSearch: true,
@@ -32,29 +32,29 @@ export function setupRoutes() {
             }),
           ],
         }),
-        'GET',
-      )
+        "GET",
+      );
     }
     if (useDynamicRoutes.length) {
       const dynamicRoutesRegexp = new RegExp(`^${baseUrl}(${useDynamicRoutes.map((r) => {
-        const parts = r.split('/')
+        const parts = r.split("/");
         parts.forEach((part, i) => {
-          if (part.startsWith(':'))
-            parts[i] = '([^/]+)'
+          if (part.startsWith(":"))
+            parts[i] = "([^/]+)";
         })
-        return `(${parts.join('/')})`
-      }).join('|')})$`)
+        return `(${parts.join("/")})`;
+      }).join("|")})$`);
       registerRoute(
-        ({ request, sameOrigin, url }) => request.destination === 'document' && sameOrigin && dynamicRoutesRegexp.test(url.pathname),
+        ({ request, sameOrigin, url }) => request.destination === "document" && sameOrigin && dynamicRoutesRegexp.test(url.pathname),
         new NetworkOnly({
           plugins: [{
             handlerDidError: async ({ state, error }) => {
               console.log(state, error)
-              return Response.redirect('/', 302)
+              return Response.redirect("/", 302)
             },
           }],
         }),
-      )
+      );
     }
   }
 }


### PR DESCRIPTION
This PR also includes:
- fix replacements in index route
- add custom sw handler for missing pages
- on ssr, allowlist  will include only `/`  to bypass precache controller (avoid infinite redirection)

closes #15