### PR TITLE
Container was not referencing anything

### DIFF
--- a/templates/template-react/src/PWABadge.css
+++ b/templates/template-react/src/PWABadge.css
@@ -1,9 +1,3 @@
-.PWABadge-container {
-    padding: 0;
-    margin: 0;
-    width: 0;
-    height: 0;
-}
 .PWABadge-toast {
     position: fixed;
     right: 0;


### PR DESCRIPTION
Deleted selector that was not selecting anything. As you can see [in the PWABadge.js](https://github.com/vite-pwa/create-pwa/blob/main/templates/template-react/src/PWABadge.jsx), the selector `.PWABadge-container` does not select anything since there's no element with the `"PWABadge-container"` class, so I removed it.

PS, perhaps it's supposed to be selecting just `.PWABadge` instead of `PWABadge-container`? Since it was not selecting anything, removing it doesn't change anything, but perhaps it was supposed to select `.PWABadge` for some edge case?